### PR TITLE
Add agent script and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Packages/
 *.xcodeproj/project.xcworkspace/xcuserdata/
 
 montana-client.conf
+app/html/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 
 ## Uso
 1. Clona este repo y asegúrate de que el remoto `origin` apunta a tu GitHub.  
-2. Ejecuta `./setup.sh` una sola vez para preparar dependencias.
-3. `git add . && git commit -m "Init MontanaOpenAiTV base" && git push origin main`  
-4. Abre `app/` en Xcode, añade `html/` al bundle, y compila tu IPA.
+2. Ejecuta `python3 agent_montana.py` una sola vez.
+3. `git add . && git commit -m "Init MontanaOpenAiTV base" && git push origin main`
+4. Abre `app/` en Xcode, añade `html/` al bundle y compila tu IPA.
+
+### Seguridad
+El archivo de ejemplo `vpn/montana-client.conf` utiliza valores ficticios.
+Nunca subas tus claves reales de WireGuard ni otros datos sensibles al repositorio.
 

--- a/agent_montana.py
+++ b/agent_montana.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import os
+import platform
+import subprocess
+import shutil
+
+
+def run_setup():
+    if os.path.exists("setup.sh"):
+        print("Ejecutando setup.sh...")
+        subprocess.run(["chmod", "+x", "setup.sh"], check=True)
+        subprocess.run(["./setup.sh"], check=True)
+    else:
+        print("No se encontró setup.sh en la raíz del proyecto.")
+
+def verificar_estructura():
+    print("\nVerificando carpetas esenciales...")
+    dirs = ["app", "addon", "html", "vpn"]
+    for d in dirs:
+        if os.path.isdir(d):
+            print(f"{d}/ OK")
+        else:
+            print(f"{d}/ NO encontrada")
+
+def empaquetar_html():
+    print("\nEmpaquetando contenido HTML...")
+    if os.path.isdir("html"):
+        dest = os.path.join("app", "html")
+        if os.path.exists(dest):
+            shutil.rmtree(dest)
+        shutil.copytree("html", dest)
+        print(f"HTML copiado a {dest}")
+    else:
+        print("Carpeta html/ no existe, se omite.")
+
+def main():
+    print("Agent Montana ACTIVADO.")
+    os_type = platform.system()
+    print(f"Sistema detectado: {os_type}\n")
+
+    run_setup()
+    verificar_estructura()
+    empaquetar_html()
+
+    print("\nMisi\u00F3n completada. Agent Montana fuera.")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -e
+# Setup script for MontanaOpenAiTV
 
 echo "🔥 Iniciando configuración de MontanaOpenAiTV..."
 
-# Paso 1: Instalar dependencias de Node (si hay en addon o app)
+# Paso 1: Instalar dependencias de Node
 if [ -f "addon/package.json" ]; then
   echo "📦 Instalando dependencias de Node para el addon..."
   cd addon
@@ -18,11 +19,11 @@ if [ -f "app/package.json" ]; then
   cd ..
 fi
 
-# Paso 2: Preparar HTML si hace falta (opcional)
-echo "🌐 Verificando carpeta html/"
-ls -la html
+# Paso 2: Verificar carpeta HTML
+echo "🌐 Contenido de la carpeta html/:"
+ls -la html || echo "⚠️  No se encontró la carpeta html"
 
-# Paso 3: Configurar VPN si es necesario (a futuro)
+# Paso 3: Ejecutar configuración de VPN si existe
 if [ -f "vpn/setup.sh" ]; then
   echo "🔐 Ejecutando configuración de VPN..."
   chmod +x vpn/setup.sh


### PR DESCRIPTION
## Summary
- add agent_montana.py helper for running setup and preparing HTML
- mention the new script in README usage instructions
- ignore generated app/html directory

## Testing
- `python3 agent_montana.py`

------
https://chatgpt.com/codex/tasks/task_e_687bc9b1f7c8832a8259b7e4d86f4161