### PR TITLE
Ignore old repo archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Packages/
 *.xcodeproj/project.xcworkspace/xcuserdata/
 
 montana-client.conf
+
+# Avoid committing packaged archives
+MontanaOpenAiTV_Repo.zip

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ usando tu propia VPN (WireGuard) y un addon de Stremio personalizado.
 
 ---
 Proyecto iniciado por @M264921 con ❤️ y ayudita de ChatGPT.
+
+## Archivos de grandes dimensiones
+
+El archivo `MontanaOpenAiTV_Repo.zip` contenía una copia del repositorio para
+distribución rápida. Ya no es necesario para ejecutar el proyecto y se ha
+eliminado del código fuente. En caso de requerirse, puede alojarse en la
+sección de _Releases_ en GitHub en lugar de almacenarse dentro del
+repositorio.


### PR DESCRIPTION
## Summary
- ignore `MontanaOpenAiTV_Repo.zip`
- document why the archive isn't included anymore

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68825fd56634832abdc20ea58dac3cab