### PR TITLE
Update HTML to load AceStream scripts from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ usando tu propia VPN (WireGuard) y un addon de Stremio personalizado.
 
 ---
 Proyecto iniciado por @M264921 con ❤️ y ayudita de ChatGPT.
+
+## Scripts AceStream
+
+Los archivos `P2P_Search.min.acestream.js` y `Magic_Player.acestream.js` forman parte del proyecto **Ace Script** de AceStream. No se incluyen en este repositorio por cuestiones de licencia.
+
+En `html/app_index.html` e `index.html` se enlazan a través del CDN público de AceStream:
+
+```html
+<script src="https://cdn.jsdelivr.net/gh/acestream/ace-script@latest/dist/P2P_Search.min.acestream.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/acestream/ace-script@latest/dist/Magic_Player.acestream.js"></script>
+```
+
+Si deseas utilizarlos en local, descárgalos desde [https://github.com/acestream/ace-script](https://github.com/acestream/ace-script) y colócalos junto a tus archivos HTML.

--- a/html/app_index.html
+++ b/html/app_index.html
@@ -4,8 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <title>MontanaOpenAiTV</title>
-    <script src="P2P_Search.min.acestream.js"></script>
-    <script src="Magic_Player.acestream.js"></script>
+    <!-- Carga los scripts oficiales de AceStream desde su CDN -->
+    <script src="https://cdn.jsdelivr.net/gh/acestream/ace-script@latest/dist/P2P_Search.min.acestream.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/acestream/ace-script@latest/dist/Magic_Player.acestream.js"></script>
     <script>
         function playStream() {
             const input = document.getElementById('ace_id').value.trim();

--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <title>MontanaOpenAiTV</title>
-    <script src="P2P_Search.min.acestream.js"></script>
-    <script src="Magic_Player.acestream.js"></script>
+    <!-- Carga los scripts oficiales de AceStream desde su CDN -->
+    <script src="https://cdn.jsdelivr.net/gh/acestream/ace-script@latest/dist/P2P_Search.min.acestream.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/acestream/ace-script@latest/dist/Magic_Player.acestream.js"></script>
     <script>
         function playStream() {
             const input = document.getElementById('ace_id').value.trim();


### PR DESCRIPTION
## Summary
- use AceStream CDN URLs for `P2P_Search.min.acestream.js` and `Magic_Player.acestream.js`
- document how to get these scripts in README

## Testing
- `bash setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68825fdb42f0832a873e07b51fd4796a