### PR TITLE
Add HTML5 player prototype with open-with launcher

### DIFF
--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MontanaOpenAiTV — Player</title>
+</head>
+<body>
+  <h1>MontanaOpenAiTV — Player (prototipo)</h1>
+
+  <label for="streamUrl">URL del stream (m3u8/HLS o MP4):</label>
+  <input id="streamUrl" type="url" placeholder="https://…/playlist.m3u8" style="width:100%;max-width:800px" />
+  <button id="btnPlay">Reproducir aquí</button>
+
+  <div style="margin:1rem 0;">
+    <video id="player" playsinline controls style="width:100%;max-width:800px;height:auto;"></video>
+  </div>
+
+  <h2>Abrir con…</h2>
+  <p>Selecciona la app destino (se configuran en <code>js/config.js</code>):</p>
+  <div id="openWith">
+    <button data-app="safari">Safari</button>
+    <button data-app="vlc">VLC</button>
+    <button data-app="infuse">Infuse</button>
+    <button data-app="kodi">Kodi</button>
+  </div>
+
+  <!-- hls.js (para reproducir m3u8 en navegadores que no soportan HLS nativo) -->
+  <script src="https://unpkg.com/hls.js@1.5.8/dist/hls.min.js"></script>
+
+  <script src="./js/config.js"></script>
+  <script src="./js/player.js"></script>
+  <script src="./js/open-with.js"></script>
+</body>
+</html>

--- a/clients/web/js/config.js
+++ b/clients/web/js/config.js
@@ -1,0 +1,17 @@
+/**
+ * Config de “Abrir con…”.
+ * NO asumimos esquemas exactos: pon aquí los que tú confirmes en tu iPhone.
+ * Ejemplos (a validar en tu dispositivo):
+ * - Safari: usar https normal (window.open)
+ * - VLC iOS: (placeholder) "vlc-x-callback://x-callback-url/stream?url="
+ * - Infuse iOS: (placeholder) "infuse://x-callback-url/play?url="
+ * - Kodi (si tienes manejador de esquema): (placeholder) "kodi://play?url="
+ */
+const OPEN_WITH = {
+  safari: url => url, // abrir tal cual en una pestaña/ventana
+  vlc:    url => `<<PON_AQUI_ESQUEMA_VLC_COMPROBADO>>${encodeURIComponent(url)}`,
+  infuse: url => `<<PON_AQUI_ESQUEMA_INFUSE_COMPROBADO>>${encodeURIComponent(url)}`,
+  kodi:   url => `<<PON_AQUI_ESQUEMA_KODI_COMPROBADO>>${encodeURIComponent(url)}`
+};
+
+window.__OPEN_WITH__ = OPEN_WITH;

--- a/clients/web/js/open-with.js
+++ b/clients/web/js/open-with.js
@@ -1,0 +1,30 @@
+(function () {
+  const $ = s => document.querySelector(s);
+  const container = $('#openWith');
+  const input = document.querySelector('#streamUrl');
+
+  function openIn(app, url) {
+    if (!url) return alert('Primero escribe una URL de stream');
+    const map = window.__OPEN_WITH__;
+    if (!map || !map[app]) return alert('App no configurada: ' + app);
+
+    const target = map[app](url);
+
+    // Safari/web: abrir http/https en nueva pestaña
+    if (app === 'safari') {
+      window.open(target, '_blank', 'noopener');
+      return;
+    }
+
+    // Para esquemas personalizados (vlc://, infuse://, kodi://…)
+    // En iOS WKWebView lo ideal es interceptarlos en la app nativa (Swift)
+    // y abrirlos con UIApplication.shared.open(_:).
+    window.location.href = target;
+  }
+
+  container.addEventListener('click', (ev) => {
+    if (ev.target.matches('button[data-app]')) {
+      openIn(ev.target.dataset.app, input.value.trim());
+    }
+  });
+})();

--- a/clients/web/js/player.js
+++ b/clients/web/js/player.js
@@ -1,0 +1,33 @@
+(function () {
+  const $ = s => document.querySelector(s);
+  const streamInput = $('#streamUrl');
+  const btnPlay = $('#btnPlay');
+  const video = $('#player');
+
+  function isM3U8(u) {
+    try { return new URL(u).pathname.endsWith('.m3u8'); } catch { return false; }
+  }
+
+  async function play(url) {
+    if (!url) return alert('Pon una URL de stream (m3u8 o MP4)');
+    // Safari en iOS suele soportar HLS nativamente en <video>,
+    // en Chrome/Firefox de escritorio necesitamos hls.js.
+    if (isM3U8(url) && window.Hls && !video.canPlayType('application/vnd.apple.mpegurl')) {
+      const hls = new Hls();
+      hls.loadSource(url);
+      hls.attachMedia(video);
+      hls.on(Hls.Events.ERROR, (ev, data) => {
+        console.error('HLS error', data);
+        alert('Error en HLS: ' + (data && data.details ? data.details : 'desconocido'));
+      });
+    } else {
+      video.src = url;
+    }
+    video.play().catch(err => {
+      console.error(err);
+      alert('No se pudo iniciar la reproducción: ' + err.message);
+    });
+  }
+
+  btnPlay.addEventListener('click', () => play(streamInput.value.trim()));
+})();

--- a/docs/and-a-dinosaur-integracion.md
+++ b/docs/and-a-dinosaur-integracion.md
@@ -1,0 +1,166 @@
+# Guía de integración de utilidades de "And a Dinosaur" en Yavale
+
+## 1. Contexto general
+
+Este documento describe una posible ruta de trabajo para incorporar, dentro del ecosistema del proyecto **MontanaOpenAiTV / Yavale**, varias funcionalidades inspiradas en las herramientas publicadas en la página *And a Dinosaur*. El objetivo es mejorar la experiencia de reproducción, depuración y distribución de contenidos en televisores y dispositivos Apple TV manteniendo un stack lo más cercano posible a la base existente.
+
+La guía está pensada como apoyo para el desarrollador que mantiene el repositorio `yavale` en su entorno local.
+
+## 2. Preparación del entorno
+
+1. **Clonar o actualizar el repositorio**
+   - Verifica que cuentas con `git` y las dependencias necesarias (`node`, `npm` y/o `python`, según el flujo de trabajo actual del proyecto).
+   - Ejecuta en tu máquina:
+     ```bash
+     git clone https://github.com/<tu-usuario>/yavale.git
+     cd yavale
+     git remote add upstream git@github.com:MontanaOpenAiTV/yavale.git  # si no existe
+     git fetch upstream
+     git checkout main
+     git pull upstream main
+     ```
+   - Para entornos ya clonados, basta con entrar en la carpeta y hacer `git pull`.
+
+2. **Instalar dependencias del proyecto**
+   - Revisa `README.md` y los scripts de `setup.sh` para confirmar los requisitos.
+   - Instala las dependencias base:
+     ```bash
+     npm install         # si el frontend se construye con Node
+     pip install -r requirements.txt  # si existe backend en Python
+     ```
+   - Valida el funcionamiento ejecutando los comandos de arranque habituales (por ejemplo `npm run dev` o el script que utilices para montar el servidor).
+
+3. **Crear un entorno de pruebas**
+   - Configura un Apple TV o dispositivo AirPlay en la misma red para validar la transmisión.
+   - Ten a mano un navegador compatible (Safari, Chrome) con soporte para extensiones de WebKit.
+   - Considera utilizar un túnel SSH hacia una red de pruebas si necesitas exponer el entorno local.
+
+## 3. Integración por funcionalidades
+
+### 3.1 Vinegar (sustituir el reproductor de YouTube)
+
+**Objetivo**: incorporar soporte para reproducir vídeos de YouTube mediante `<video>` nativo dentro de Yavale.
+
+1. **Analizar la capa de reproducción actual**
+   - Ubica el componente o módulo encargado de mostrar el reproductor (por ejemplo dentro de `app/` o `html/`).
+   - Documenta qué librería utiliza actualmente (YouTube IFrame API, reproductores personalizados, etc.).
+
+2. **Implementar un "modo Vinegar"**
+   - Crea un wrapper que extraiga el enlace de streaming MP4/HLS de cada vídeo.
+   - Utiliza la API de YouTube (o servicios de extracción permitidos) para obtener URL directas.
+   - Renderiza un `<video>` nativo con los atributos `controls`, `playsinline`, `autoplay` y soporte para PiP.
+
+3. **Privacidad y control**
+   - Añade opciones en la configuración (`manifest.json` o panel de ajustes) para activar/desactivar este modo.
+   - Bloquea la carga de scripts de seguimiento innecesarios (por ejemplo, filtrando `youtube.com/iframe_api`).
+
+4. **Pruebas**
+   - Verifica la reproducción, la entrada en PiP y el audio en segundo plano.
+   - Comprueba que no se muestran anuncios ni se abren ventanas emergentes.
+
+### 3.2 Baking Soda (soporte para otros reproductores)
+
+**Objetivo**: generalizar la sustitución por `<video>` en cualquier sitio embebido.
+
+1. **Detección del proveedor**
+   - Implementa un módulo que identifique el origen del reproductor (por ejemplo, Twitch, Vimeo, Dailymotion).
+   - Define adaptadores que traduzcan cada origen a una URL de streaming compatible.
+
+2. **Inyección controlada**
+   - Si el reproductor se carga dentro de un `webview`, añade lógica para reemplazar dinámicamente el elemento por `<video>`.
+   - Para contenido remoto, utiliza `Content-Security-Policy` para evitar bloqueos.
+
+3. **Fallback**
+   - Mantén un modo de compatibilidad que use el reproductor original si no se logra obtener la URL nativa.
+
+4. **Monitorización**
+   - Registra métricas básicas (tiempo de carga, errores de reproducción) para evaluar la eficacia de la sustitución.
+
+### 3.3 Web Inspector (inspección del DOM en iOS/iPadOS)
+
+**Objetivo**: facilitar la depuración desde dispositivos móviles de Apple.
+
+1. **Habilitar el inspector remoto**
+   - Activa las banderas necesarias en el proyecto para permitir la depuración remota (por ejemplo, `WKWebView` con `allowsLinkPreview = false` y `isInspectable = true`).
+   - Documenta cómo emparejar el dispositivo iOS/iPadOS con un Mac para usar Web Inspector.
+
+2. **Guía de uso**
+   - Incluye instrucciones paso a paso para inspeccionar el DOM, revisar estilos y analizar peticiones.
+   - Recomienda flujos de trabajo para resolver problemas de reproducción o layout.
+
+### 3.4 Teleplayer (listas y AirPlay)
+
+**Objetivo**: ofrecer una experiencia de listas de reproducción con envío a Apple TV.
+
+1. **Diseño de la funcionalidad**
+   - Añade en la UI de Yavale un módulo de "cola" o "playlist" inspirado en Teleplayer.
+   - Permite añadir vídeos desde ACE Streams, URLs directas o resultados de búsqueda.
+
+2. **Integración con AirPlay**
+   - Si usas un cliente macOS, reutiliza `AVQueuePlayer` y la API de AirPlay.
+   - Desde Yavale, expón un botón `AirPlay` que invoque la API de `navigator.mediaSession` o un puente nativo.
+
+3. **Gestión de energía**
+   - Implementa en el cliente macOS un mecanismo que evite que el equipo entre en reposo mientras haya reproducción.
+
+4. **Sincronización de estados**
+   - Guarda el progreso de cada vídeo para retomar la reproducción al volver al Apple TV.
+
+### 3.5 Makeover (personalización con CSS/JS)
+
+**Objetivo**: permitir personalizar la interfaz de Yavale mediante inyecciones controladas.
+
+1. **Motor de temas**
+   - Crea una carpeta `addon/themes/` donde almacenar CSS/JS personalizados.
+   - Define una convención (por ejemplo, `manifest.json` por tema) que indique qué archivos se cargan.
+
+2. **Panel de administración**
+   - Añade una interfaz que permita activar/desactivar temas y editar reglas CSS en caliente.
+   - Implementa un preview con `postMessage` o WebSockets para reflejar cambios al vuelo.
+
+3. **Seguridad**
+   - Restringe las APIs disponibles para el JavaScript inyectado (por ejemplo, sandboxing con `iframe` o `Trusted Types`).
+
+### 3.6 Crappy VPN (túneles SSH simplificados)
+
+**Objetivo**: facilitar el acceso remoto a recursos sin requerir un VPN completo.
+
+1. **Scripts de automatización**
+   - Crea scripts en `vpn/` que establezcan túneles SSH con los parámetros adecuados.
+   - Permite configurar host, puerto y clave privada mediante variables de entorno.
+
+2. **Integración con Yavale**
+   - Expón una interfaz CLI o web que muestre el estado del túnel y permita reconectarlo.
+   - Documenta casos de uso típicos: acceso al servidor ACE Stream remoto, reenvío de puertos a Apple TV en otra red, etc.
+
+3. **Gestión de credenciales**
+   - Usa el llavero del sistema o un gestor de secretos para almacenar claves.
+   - Añade ejemplos de configuración en `montana-server.conf` y `montana-client.conf`.
+
+## 4. Roadmap sugerido
+
+1. Prioriza la sustitución por `<video>` en YouTube (Vinegar) para obtener beneficios inmediatos en privacidad y PiP.
+2. Extiende la lógica a otros servicios (Baking Soda) reutilizando componentes.
+3. Integra Teleplayer para mejorar la reproducción en Apple TV y mantener al Mac despierto.
+4. Habilita herramientas de depuración (Web Inspector) y personalización (Makeover) para iterar rápidamente.
+5. Automatiza el acceso remoto con Crappy VPN para el equipo distribuidor.
+
+Para cada etapa, prepara pruebas automáticas o manuales que aseguren la compatibilidad con los flujos existentes.
+
+## 5. Buenas prácticas generales
+
+- Mantén la documentación actualizada (incluyendo este archivo) con cada funcionalidad nueva.
+- Agrega pruebas unitarias/e2e cuando sea posible para validar la reproducción.
+- Usa ramas específicas (`feature/vinegar`, `feature/teleplayer`, etc.) y revisiones de código frecuentes.
+- Documenta en `README.md` cómo activar o desactivar cada módulo para que otros colaboradores puedan replicar el entorno.
+
+## 6. Recursos adicionales
+
+- [And a Dinosaur – Extensiones](https://andadinosaur.com/) (consulta las páginas individuales para detalles técnicos).
+- Documentación de YouTube Data API y IFrame API.
+- Guías de Apple para `AVKit`, AirPlay y Web Inspector.
+- Manuales de OpenSSH para la creación de túneles y reenvío de puertos.
+
+---
+
+Este plan es una base; ajusta las prioridades y la profundidad de implementación según las necesidades del proyecto y la disponibilidad de recursos.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "yavale",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yavale",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "yavale",
+  "version": "1.0.0",
+  "description": "Plataforma personal para reproducir enlaces AceStream desde iOS, navegador o cualquier dispositivo, usando tu propia VPN (WireGuard) y un addon de Stremio personalizado.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev:web": "node ./scripts/dev-server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+const { createReadStream, existsSync, statSync } = require('node:fs');
+const { createServer } = require('node:http');
+const { extname, join, resolve } = require('node:path');
+
+const PORT = Number(process.env.PORT || 5173);
+const ROOT = resolve('clients/web');
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.m3u8': 'application/vnd.apple.mpegurl'
+};
+
+function send(res, status, headers, stream) {
+  res.writeHead(status, headers);
+  if (stream) {
+    stream.pipe(res);
+  } else {
+    res.end();
+  }
+}
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url || '/', 'http://localhost');
+  let filePath = join(ROOT, decodeURIComponent(url.pathname));
+
+  if (!existsSync(filePath)) {
+    return send(res, 404, { 'content-type': 'text/plain; charset=utf-8' }, null);
+  }
+
+  const stats = statSync(filePath);
+  if (stats.isDirectory()) {
+    filePath = join(filePath, 'index.html');
+    if (!existsSync(filePath)) {
+      return send(res, 403, { 'content-type': 'text/plain; charset=utf-8' }, null);
+    }
+  }
+
+  const mime = MIME[extname(filePath).toLowerCase()] || 'application/octet-stream';
+  const stream = createReadStream(filePath);
+  send(res, 200, { 'content-type': mime, 'cache-control': 'no-store' }, stream);
+});
+
+server.listen(PORT, () => {
+  console.log(`Servidor estático listo en http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create a minimal web client skeleton under `clients/web` with an HTML5 video player and HLS fallback via hls.js
- wire a configurable "Abrir con…" launcher so the stream URL can be forwarded to Safari, VLC, Infuse, or Kodi once the real schemes are confirmed
- add a lightweight Node-based dev server script and npm metadata to serve the prototype locally

## Testing
- not run (static prototype)


------
https://chatgpt.com/codex/tasks/task_e_68d7645d9384832a97f9b5409a82d9ce