### PR TITLE
feat: allow custom player presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ Variables de entorno soportadas en el addon:
 
 > Cada vez que edites la M3U8, repite el script y vuelve a subir los cambios para mantener la pagina sincronizada.
 
+### Personalizar la lista de reproductores
+
+- Edita `playlists/player-presets.json` para reflejar los dispositivos y apps reales que tienes instalados.
+- Cada preset acepta los campos:
+  - `id`: identificador unico (sin espacios) para referencias internas.
+  - `label`: el texto que veras en el desplegable.
+  - `type`: actualmente `acestream` (usa el enlace tal cual / convierte magnet a hash) o `template`.
+  - `template`: (solo si `type` es `template`) URL con placeholders disponibles:
+    - `{{url}}` / `{{url_raw}}` - enlace completo codificado / sin codificar.
+    - `{{infohash}}` / `{{infohash_encoded}}` - hash AceStream si el enlace lo incluye.
+    - `{{title}}` / `{{title_encoded}}` - titulo del canal.
+  - `icon` (opcional): ruta o URL a un icono de 18x18px para mostrar junto al nombre.
+- Opcional: crea otros presets en un fichero alternativo y ejecútalo con `PLAYER_PRESETS=mi-archivo.json npm run generate:playlist`.
+- Cuando uses la variable `PLAYER_PRESETS`, la ruta se resuelve respecto a la raiz del repo (puedes pasar rutas absolutas si lo prefieres).
+- El script de PowerShell `scripts/update-playlist.ps1` acepta `-PlayerPresetPath "ruta\a\mis-presets.json"` para automatizar este override.
+- Si el archivo contiene errores o campos faltantes, el generador volvera a los valores por defecto y avisara en consola.
+
 ## Estructura resumida
 
 ```
@@ -69,6 +86,7 @@ scripts/
   generate-playlist-page.js
 playlists/
   playlist.m3u8        # Ultima copia versionada de tu lista
+  player-presets.json  # Ejemplo de configuracion para el selector de reproductor
 docs/
   index.html           # Pagina publica (GitHub Pages)
   playlist.json        # Datos parseados (util para APIs/automatizaciones)

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,38 +110,71 @@
       background: rgba(148, 163, 184, 0.15);
       color: inherit;
     }
-    details.player-picker {
-      background: rgba(15, 23, 42, 0.35);
-      border-radius: 0.75rem;
-      border: 1px solid rgba(148, 163, 184, 0.2);
-      padding: 0.5rem;
+    .player-dropdown {
+      position: relative;
+      width: 100%;
     }
-    details.player-picker summary {
-      cursor: pointer;
-      list-style: none;
-      font-weight: 600;
-      padding: 0.3rem 0.4rem;
+    .player-dropdown__toggle {
+      width: 100%;
+      justify-content: space-between;
     }
-    details.player-picker summary::-webkit-details-marker {
+    .player-dropdown__arrow {
+      display: inline-block;
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 6px solid currentColor;
+      transition: transform 120ms ease;
+    }
+    .player-dropdown.is-open .player-dropdown__arrow {
+      transform: rotate(180deg);
+    }
+    .player-dropdown__menu {
+      position: absolute;
+      top: calc(100% + 0.35rem);
+      left: 0;
+      right: 0;
       display: none;
-    }
-    .player-picker__list {
-      display: flex;
       flex-direction: column;
       gap: 0.4rem;
-      margin: 0.5rem 0 0;
-      padding: 0;
+      margin: 0;
+      padding: 0.6rem;
       list-style: none;
+      border-radius: 0.9rem;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.95);
+      box-shadow: 0 18px 28px rgba(15, 23, 42, 0.45);
+      z-index: 10;
     }
-    .player-picker__list a {
+    .player-dropdown.is-open .player-dropdown__menu {
+      display: flex;
+    }
+    .player-dropdown__menu li a {
       display: inline-flex;
       align-items: center;
-      gap: 0.35rem;
-      padding: 0.5rem 0.6rem;
-      border-radius: 0.55rem;
+      justify-content: flex-start;
+      gap: 0.45rem;
+      padding: 0.55rem 0.7rem;
+      border-radius: 0.6rem;
       text-decoration: none;
       color: #38bdf8;
       background: rgba(56, 189, 248, 0.12);
+      transition: background 120ms ease, color 120ms ease;
+    }
+    .player-dropdown__menu li a img {
+      width: 18px;
+      height: 18px;
+      object-fit: contain;
+      filter: drop-shadow(0 0 2px rgba(15, 23, 42, 0.6));
+    }
+    .player-dropdown__menu li a span {
+      flex: 1;
+    }
+    .player-dropdown__menu li a:hover,
+    .player-dropdown__menu li a:focus-visible {
+      background: rgba(56, 189, 248, 0.2);
+      color: #f0f9ff;
     }
     footer {
       font-size: 0.8rem;
@@ -169,7 +202,12 @@
         background: rgba(148, 163, 184, 0.2);
         color: inherit;
       }
-      .player-picker__list a {
+      .player-dropdown__menu {
+        background: rgba(255, 255, 255, 0.95);
+        border: 1px solid rgba(148, 163, 184, 0.45);
+        box-shadow: 0 18px 28px rgba(148, 163, 184, 0.25);
+      }
+      .player-dropdown__menu li a {
         color: #2563eb;
         background: rgba(37, 99, 235, 0.12);
       }
@@ -179,7 +217,7 @@
 <body>
   <header>
     <h1>Playlist AceStream</h1>
-    <p>Actualizada: 2025-10-01T19:25:19.092Z</p>
+    <p>Actualizada: 2025-10-01T21:01:57.300Z</p>
     <div class="toolbar">
       <input id="search" type="search" placeholder="Buscar por nombre, grupo o ID" />
       <select id="group">
@@ -192,7 +230,7 @@
   <footer>Generado desde playlist.m3u8 - Proyecto YaVale</footer>
   <script>
     const playlist = [{"title":"M. Deportes HD","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:8aba55f4f1f47def54447e845518109d797339e7"},{"title":"M. LaLiga","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:c1959a27edb0b94c5005a2dea93b7a70d4312f1c"},{"title":"F1","attributes":{"acestream-autosearch":"1","group-title":"2025"},"duration":-1,"url":"magnet:?xt=urn:btih:b0999d6facfbae2944b9c7bba442eeea9cd9d4b2"},{"title":"DAZN4","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:c21a2524a8de3e1e5b126f2677a3e993d9aa07c4"},{"title":"DAZN3","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:98fba924421aa1e4bd28e74d74a2726d0459b594"},{"title":"Alien Planeta Tierra","attributes":{"acestream-autosearch":"1"},"duration":-1,"url":"magnet:?xt=urn:btih:eb197728d8790127be4e866e7500a70f82687afd"},{"title":"Champions League","attributes":{"group-title":"futbol"},"duration":-1,"url":"acestream://06013d0c0dcdd677ae09363db1b1f93bd97589bd"},{"title":"DAZN1","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:0560234787945a17522e284c4c22bb4df29f33b0"},{"title":"DAZN2","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:c93a0d4914713db942fbb210bac467b0224c63a6"},{"title":"s","attributes":{"acestream-autosearch":"1","group-title":"deportes"},"duration":-1,"url":"magnet:?xt=urn:btih:868cf72e65093a8eb9fc4b9c78ed90c2dd7fdb7f"},{"title":"M. Golf HD","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:b715ba3d23d3dca6736ac86990efe105087c3401"},{"title":"DAZ","attributes":{"acestream-autosearch":"1","group-title":"amateur"},"duration":-1,"url":"magnet:?xt=urn:btih:61b4e295ae003dc415babbe7c7a6c37507bd4c80"},{"title":"LALIGA","attributes":{"acestream-autosearch":"1","group-title":"amateur"},"duration":-1,"url":"magnet:?xt=urn:btih:8a25653a2f774f4ae1062d38a30dcd714d304a3a"},{"title":"NBA TV [US]","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:cc3dea4f93071fed3f67be4518618cd73a6ca77a"},{"title":"Campeones 1080 elcano.top zeronet http://127.0.0.1:43110/18D6dPcsjLrjg2hhnYqKzNh2W6QtXrDwF/  https://ipfs.io/ipns/elcano.top","attributes":{"group-title":"sport"},"duration":-1,"url":"acestream://97df5b7824948972d041d8ca2a4d29c90b641bc9"},{"title":"M. Liga de Campeones","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:8c1c3eae077f3a786ed2f0a426197ea93fdf7373"},{"title":"M. Liga de Campeones 2","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:cc3d749cfd30877b418f1d59a80d9291e0f091c8"},{"title":"M. Liga de Campeones 3","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:8cc8e3c092fa238bc0cbc65382ae436131fc3eab"},{"title":"DAZN F1 HD","attributes":{"acestream-autosearch":"1","group-title":"sport"},"duration":-1,"url":"magnet:?xt=urn:btih:6d325cda6ed591647ef5e91edd043147bce8be30"}];
-    const players = [{"id":"acestream","label":"Ace Stream (engine local)","type":"acestream"},{"id":"vlc","label":"VLC (iOS/macOS)","type":"template","template":"vlc-x-callback://x-callback-url/stream?url={{url}}"},{"id":"infuse","label":"Infuse","type":"template","template":"infuse://x-callback-url/play?url={{url}}"},{"id":"kodi","label":"Kodi","type":"template","template":"kodi://play?item={{url}}"}];
+    const players = [{"id":"living-room","label":"Sala de estar (Chromecast)","type":"template","template":"acecast://device/living-room/play?infohash={{infohash}}&title={{title_encoded}}"},{"id":"lg-oled65c4","label":"[LG] webOS TV OLED65C4","type":"template","template":"acecast://device/lg-oled65c4/play?infohash={{infohash}}&title={{title_encoded}}"},{"id":"aftss","label":"AFTSS (AceCast)","type":"template","template":"acecast://device/aftss/play?infohash={{infohash}}&title={{title_encoded}}"},{"id":"ace-player-hd","label":"Ace Player HD","type":"template","template":"acestream://{{infohash}}"},{"id":"windows-media-player","label":"Reproductor de Windows Media","type":"template","template":"wmplayer.exe?{{url_raw}}"}];
     const playlistContainer = document.getElementById("playlist");
     const searchInput = document.getElementById("search");
     const groupFilter = document.getElementById("group");
@@ -205,30 +243,161 @@
       groupFilter.appendChild(option);
     }
 
-    function buildPlayerUrl(player, url) {
+    function extractInfoHash(url) {
+      if (!url) {
+        return "";
+      }
+
+      if (url.startsWith("acestream://")) {
+        return url.slice("acestream://".length);
+      }
+
+      const magnetPrefix = "magnet:?xt=urn:btih:";
+      if (url.startsWith(magnetPrefix)) {
+        const hashSection = url.slice(magnetPrefix.length);
+        const endIndex = hashSection.indexOf("&");
+        return endIndex === -1
+          ? hashSection
+          : hashSection.slice(0, endIndex);
+      }
+
+      return "";
+    }
+
+    function buildPlayerUrl(player, item) {
+      const url = item.url;
+      const infohash = extractInfoHash(url);
+      const title = item.title || "";
+
       if (player.type === "acestream") {
         if (url.startsWith("acestream://")) {
           return url;
         }
         if (url.startsWith("magnet:?xt=urn:btih:")) {
-          const hash = url.split("magnet:?xt=urn:btih:")[1];
-          return "acestream://" + hash;
+          return infohash ? "acestream://" + infohash : url;
         }
         return url;
       }
 
       if (player.type === "template" && player.template) {
         const encoded = encodeURIComponent(url);
+        const encodedTitle = encodeURIComponent(title);
+        const encodedInfoHash = encodeURIComponent(infohash);
         let result = player.template;
         result = result.split("{{url}}").join(encoded);
         result = result.split("{{url_raw}}").join(url);
+        result = result.split("{{infohash}}").join(infohash);
+        result = result.split("{{infohash_encoded}}").join(encodedInfoHash);
+        result = result.split("{{title}}").join(title);
+        result = result.split("{{title_encoded}}").join(encodedTitle);
         return result;
       }
 
       return url;
     }
 
+    let activeDropdown = null;
+
+    function closeActiveDropdown() {
+      if (!activeDropdown) {
+        return;
+      }
+      const toggle = activeDropdown.querySelector(".player-dropdown__toggle");
+      if (toggle) {
+        toggle.setAttribute("aria-expanded", "false");
+      }
+      activeDropdown.classList.remove("is-open");
+      activeDropdown = null;
+    }
+
+    document.addEventListener("click", (event) => {
+      if (!activeDropdown) {
+        return;
+      }
+      if (activeDropdown.contains(event.target)) {
+        return;
+      }
+      closeActiveDropdown();
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        closeActiveDropdown();
+      }
+    });
+
+    function createPlayerDropdown(item, index) {
+      const dropdown = document.createElement("div");
+      dropdown.className = "player-dropdown";
+
+      const toggle = document.createElement("button");
+      toggle.type = "button";
+      toggle.className = "player-dropdown__toggle play";
+      toggle.textContent = "Reproducir";
+      toggle.setAttribute("aria-haspopup", "true");
+      const arrow = document.createElement("span");
+      arrow.className = "player-dropdown__arrow";
+      toggle.appendChild(arrow);
+
+      const menu = document.createElement("ul");
+      menu.className = "player-dropdown__menu";
+      const menuId = "player-menu-" + index;
+      menu.id = menuId;
+      menu.setAttribute("role", "menu");
+      toggle.setAttribute("aria-controls", menuId);
+      toggle.setAttribute("aria-expanded", "false");
+
+      toggle.addEventListener("click", () => {
+        const isOpen = dropdown.classList.contains("is-open");
+        if (isOpen) {
+          dropdown.classList.remove("is-open");
+          toggle.setAttribute("aria-expanded", "false");
+          if (activeDropdown === dropdown) {
+            activeDropdown = null;
+          }
+          return;
+        }
+        closeActiveDropdown();
+        dropdown.classList.add("is-open");
+        toggle.setAttribute("aria-expanded", "true");
+        activeDropdown = dropdown;
+      });
+
+      for (const player of players) {
+        const li = document.createElement("li");
+        const link = document.createElement("a");
+        link.href = buildPlayerUrl(player, item);
+        link.target = "_blank";
+        link.rel = "noreferrer";
+        link.setAttribute("role", "menuitem");
+
+        if (player.icon) {
+          const icon = document.createElement("img");
+          icon.src = player.icon;
+          icon.alt = "";
+          icon.width = 18;
+          icon.height = 18;
+          icon.setAttribute("aria-hidden", "true");
+          link.appendChild(icon);
+        }
+
+        const labelSpan = document.createElement("span");
+        labelSpan.textContent = player.label;
+        link.appendChild(labelSpan);
+        link.addEventListener("click", () => {
+          closeActiveDropdown();
+        });
+        li.appendChild(link);
+        menu.appendChild(li);
+      }
+
+      dropdown.appendChild(toggle);
+      dropdown.appendChild(menu);
+      return dropdown;
+    }
+
     function render(list) {
+      closeActiveDropdown();
       playlistContainer.innerHTML = "";
       if (!list.length) {
         const empty = document.createElement("p");
@@ -237,7 +406,7 @@
         return;
       }
 
-      for (const item of list) {
+      list.forEach((item, index) => {
         const card = document.createElement("article");
         card.className = "card";
         card.setAttribute("role", "listitem");
@@ -263,35 +432,16 @@
         const actions = document.createElement("div");
         actions.className = "actions";
 
-        const button = document.createElement("a");
-        button.className = "play";
-        button.href = item.url;
-        button.textContent = "Reproducir";
-        button.target = "_blank";
-        button.rel = "noreferrer";
-        actions.appendChild(button);
-
         if (players.length) {
-          const picker = document.createElement("details");
-          picker.className = "player-picker";
-          const summary = document.createElement("summary");
-          summary.textContent = "Seleccionar reproductor";
-          picker.appendChild(summary);
-          const listEl = document.createElement("ul");
-          listEl.className = "player-picker__list";
-
-          for (const player of players) {
-            const li = document.createElement("li");
-            const link = document.createElement("a");
-            link.textContent = player.label;
-            link.href = buildPlayerUrl(player, item.url);
-            link.target = "_blank";
-            link.rel = "noreferrer";
-            li.appendChild(link);
-            listEl.appendChild(li);
-          }
-          picker.appendChild(listEl);
-          actions.appendChild(picker);
+          actions.appendChild(createPlayerDropdown(item, index));
+        } else {
+          const fallbackLink = document.createElement("a");
+          fallbackLink.className = "play";
+          fallbackLink.href = item.url;
+          fallbackLink.textContent = "Reproducir";
+          fallbackLink.target = "_blank";
+          fallbackLink.rel = "noreferrer";
+          actions.appendChild(fallbackLink);
         }
 
         const copyBtn = document.createElement("button");
@@ -346,7 +496,7 @@
 
         card.appendChild(actions);
         playlistContainer.appendChild(card);
-      }
+      });
     }
 
     function applyFilters() {

--- a/playlists/player-presets.json
+++ b/playlists/player-presets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "living-room",
+    "label": "Sala de estar (Chromecast)",
+    "type": "template",
+    "template": "acecast://device/living-room/play?infohash={{infohash}}&title={{title_encoded}}"
+  },
+  {
+    "id": "lg-oled65c4",
+    "label": "[LG] webOS TV OLED65C4",
+    "type": "template",
+    "template": "acecast://device/lg-oled65c4/play?infohash={{infohash}}&title={{title_encoded}}"
+  },
+  {
+    "id": "aftss",
+    "label": "AFTSS (AceCast)",
+    "type": "template",
+    "template": "acecast://device/aftss/play?infohash={{infohash}}&title={{title_encoded}}"
+  },
+  {
+    "id": "ace-player-hd",
+    "label": "Ace Player HD",
+    "type": "template",
+    "template": "acestream://{{infohash}}"
+  },
+  {
+    "id": "windows-media-player",
+    "label": "Reproductor de Windows Media",
+    "type": "template",
+    "template": "wmplayer.exe?{{url_raw}}"
+  }
+]

--- a/scripts/generate-playlist-page.js
+++ b/scripts/generate-playlist-page.js
@@ -101,10 +101,10 @@ function parseExtInf(line) {
   return info;
 }
 
-const PLAYERS = [
+const DEFAULT_PLAYER_PRESETS = [
   {
-    id: "acestream",
-    label: "Ace Stream (engine local)",
+    id: "acestream-engine",
+    label: "Ace Stream (motor local)",
     type: "acestream"
   },
   {
@@ -124,11 +124,130 @@ const PLAYERS = [
     label: "Kodi",
     type: "template",
     template: "kodi://play?item={{url}}"
+  },
+  {
+    id: "ace-player-hd",
+    label: "Ace Player HD",
+    type: "template",
+    template: "acestream://{{infohash}}"
+  },
+  {
+    id: "acecast",
+    label: "AceCast (seleccionar dispositivo)",
+    type: "template",
+    template:
+      "acecast://play?method=fromHash&infohash={{infohash}}&name={{title_encoded}}"
+  },
+  {
+    id: "windows-media-player",
+    label: "Reproductor de Windows Media",
+    type: "template",
+    template: "wmplayer.exe?{{url_raw}}"
   }
 ];
 
-function buildHtml(entries) {
+function resolvePlayerPresetPath() {
+  const envPath = process.env.PLAYER_PRESETS
+    ? path.resolve(projectRoot, process.env.PLAYER_PRESETS)
+    : null;
+
+  const candidates = [
+    envPath,
+    path.join(playlistsDir, "players.json"),
+    path.join(playlistsDir, "player-presets.json")
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function loadPlayerPresets() {
+  const presetPath = resolvePlayerPresetPath();
+  if (!presetPath) {
+    return DEFAULT_PLAYER_PRESETS;
+  }
+
+  try {
+    const raw = fs.readFileSync(presetPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      console.warn(
+        `[generate-playlist] ${presetPath} no contiene un array, usando valores por defecto.`
+      );
+      return DEFAULT_PLAYER_PRESETS;
+    }
+
+    const sanitized = parsed
+      .map((entry, index) => sanitizePlayerPreset(entry, index, presetPath))
+      .filter(Boolean);
+
+    if (!sanitized.length) {
+      console.warn(
+        `[generate-playlist] No se encontraron presets válidos en ${presetPath}, usando valores por defecto.`
+      );
+      return DEFAULT_PLAYER_PRESETS;
+    }
+
+    return sanitized;
+  } catch (error) {
+    console.warn(
+      `[generate-playlist] No se pudo leer ${presetPath}, usando valores por defecto.`,
+      error
+    );
+    return DEFAULT_PLAYER_PRESETS;
+  }
+}
+
+function sanitizePlayerPreset(entry, index, presetPath) {
+  if (!entry || typeof entry !== "object") {
+    console.warn(
+      `[generate-playlist] Preset inválido en ${presetPath} (posición ${index}).`
+    );
+    return null;
+  }
+
+  const id = typeof entry.id === "string" && entry.id.trim();
+  const label = typeof entry.label === "string" && entry.label.trim();
+  const type = typeof entry.type === "string" && entry.type.trim();
+
+  if (!id || !label || !type) {
+    console.warn(
+      `[generate-playlist] Preset omitido en ${presetPath} (posición ${index}) por campos requeridos faltantes.`
+    );
+    return null;
+  }
+
+  const preset = { id, label, type };
+
+  if (type === "template") {
+    const template =
+      typeof entry.template === "string" && entry.template.trim().length
+        ? entry.template
+        : null;
+    if (!template) {
+      console.warn(
+        `[generate-playlist] Preset ${id} omitido: falta template para tipo template.`
+      );
+      return null;
+    }
+    preset.template = template;
+  }
+
+  if (entry.icon) {
+    preset.icon = entry.icon;
+  }
+
+  return preset;
+}
+
+function buildHtml(entries, playerPresets) {
   const playlistJson = JSON.stringify(entries).replace(/</g, "\\u003C");
+  const playersJson = JSON.stringify(playerPresets).replace(/</g, "\\u003C");
   const generatedAt = new Date().toISOString();
 
   return `<!DOCTYPE html>
@@ -243,38 +362,71 @@ function buildHtml(entries) {
       background: rgba(148, 163, 184, 0.15);
       color: inherit;
     }
-    details.player-picker {
-      background: rgba(15, 23, 42, 0.35);
-      border-radius: 0.75rem;
-      border: 1px solid rgba(148, 163, 184, 0.2);
-      padding: 0.5rem;
+    .player-dropdown {
+      position: relative;
+      width: 100%;
     }
-    details.player-picker summary {
-      cursor: pointer;
-      list-style: none;
-      font-weight: 600;
-      padding: 0.3rem 0.4rem;
+    .player-dropdown__toggle {
+      width: 100%;
+      justify-content: space-between;
     }
-    details.player-picker summary::-webkit-details-marker {
+    .player-dropdown__arrow {
+      display: inline-block;
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 6px solid currentColor;
+      transition: transform 120ms ease;
+    }
+    .player-dropdown.is-open .player-dropdown__arrow {
+      transform: rotate(180deg);
+    }
+    .player-dropdown__menu {
+      position: absolute;
+      top: calc(100% + 0.35rem);
+      left: 0;
+      right: 0;
       display: none;
-    }
-    .player-picker__list {
-      display: flex;
       flex-direction: column;
       gap: 0.4rem;
-      margin: 0.5rem 0 0;
-      padding: 0;
+      margin: 0;
+      padding: 0.6rem;
       list-style: none;
+      border-radius: 0.9rem;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.95);
+      box-shadow: 0 18px 28px rgba(15, 23, 42, 0.45);
+      z-index: 10;
     }
-    .player-picker__list a {
+    .player-dropdown.is-open .player-dropdown__menu {
+      display: flex;
+    }
+    .player-dropdown__menu li a {
       display: inline-flex;
       align-items: center;
-      gap: 0.35rem;
-      padding: 0.5rem 0.6rem;
-      border-radius: 0.55rem;
+      justify-content: flex-start;
+      gap: 0.45rem;
+      padding: 0.55rem 0.7rem;
+      border-radius: 0.6rem;
       text-decoration: none;
       color: #38bdf8;
       background: rgba(56, 189, 248, 0.12);
+      transition: background 120ms ease, color 120ms ease;
+    }
+    .player-dropdown__menu li a img {
+      width: 18px;
+      height: 18px;
+      object-fit: contain;
+      filter: drop-shadow(0 0 2px rgba(15, 23, 42, 0.6));
+    }
+    .player-dropdown__menu li a span {
+      flex: 1;
+    }
+    .player-dropdown__menu li a:hover,
+    .player-dropdown__menu li a:focus-visible {
+      background: rgba(56, 189, 248, 0.2);
+      color: #f0f9ff;
     }
     footer {
       font-size: 0.8rem;
@@ -302,7 +454,12 @@ function buildHtml(entries) {
         background: rgba(148, 163, 184, 0.2);
         color: inherit;
       }
-      .player-picker__list a {
+      .player-dropdown__menu {
+        background: rgba(255, 255, 255, 0.95);
+        border: 1px solid rgba(148, 163, 184, 0.45);
+        box-shadow: 0 18px 28px rgba(148, 163, 184, 0.25);
+      }
+      .player-dropdown__menu li a {
         color: #2563eb;
         background: rgba(37, 99, 235, 0.12);
       }
@@ -325,7 +482,7 @@ function buildHtml(entries) {
   <footer>Generado desde playlist.m3u8 - Proyecto YaVale</footer>
   <script>
     const playlist = ${playlistJson};
-    const players = ${JSON.stringify(PLAYERS)};
+    const players = ${playersJson};
     const playlistContainer = document.getElementById("playlist");
     const searchInput = document.getElementById("search");
     const groupFilter = document.getElementById("group");
@@ -338,30 +495,161 @@ function buildHtml(entries) {
       groupFilter.appendChild(option);
     }
 
-    function buildPlayerUrl(player, url) {
+    function extractInfoHash(url) {
+      if (!url) {
+        return "";
+      }
+
+      if (url.startsWith("acestream://")) {
+        return url.slice("acestream://".length);
+      }
+
+      const magnetPrefix = "magnet:?xt=urn:btih:";
+      if (url.startsWith(magnetPrefix)) {
+        const hashSection = url.slice(magnetPrefix.length);
+        const endIndex = hashSection.indexOf("&");
+        return endIndex === -1
+          ? hashSection
+          : hashSection.slice(0, endIndex);
+      }
+
+      return "";
+    }
+
+    function buildPlayerUrl(player, item) {
+      const url = item.url;
+      const infohash = extractInfoHash(url);
+      const title = item.title || "";
+
       if (player.type === "acestream") {
         if (url.startsWith("acestream://")) {
           return url;
         }
         if (url.startsWith("magnet:?xt=urn:btih:")) {
-          const hash = url.split("magnet:?xt=urn:btih:")[1];
-          return "acestream://" + hash;
+          return infohash ? "acestream://" + infohash : url;
         }
         return url;
       }
 
       if (player.type === "template" && player.template) {
         const encoded = encodeURIComponent(url);
+        const encodedTitle = encodeURIComponent(title);
+        const encodedInfoHash = encodeURIComponent(infohash);
         let result = player.template;
         result = result.split("{{url}}").join(encoded);
         result = result.split("{{url_raw}}").join(url);
+        result = result.split("{{infohash}}").join(infohash);
+        result = result.split("{{infohash_encoded}}").join(encodedInfoHash);
+        result = result.split("{{title}}").join(title);
+        result = result.split("{{title_encoded}}").join(encodedTitle);
         return result;
       }
 
       return url;
     }
 
+    let activeDropdown = null;
+
+    function closeActiveDropdown() {
+      if (!activeDropdown) {
+        return;
+      }
+      const toggle = activeDropdown.querySelector(".player-dropdown__toggle");
+      if (toggle) {
+        toggle.setAttribute("aria-expanded", "false");
+      }
+      activeDropdown.classList.remove("is-open");
+      activeDropdown = null;
+    }
+
+    document.addEventListener("click", (event) => {
+      if (!activeDropdown) {
+        return;
+      }
+      if (activeDropdown.contains(event.target)) {
+        return;
+      }
+      closeActiveDropdown();
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        closeActiveDropdown();
+      }
+    });
+
+    function createPlayerDropdown(item, index) {
+      const dropdown = document.createElement("div");
+      dropdown.className = "player-dropdown";
+
+      const toggle = document.createElement("button");
+      toggle.type = "button";
+      toggle.className = "player-dropdown__toggle play";
+      toggle.textContent = "Reproducir";
+      toggle.setAttribute("aria-haspopup", "true");
+      const arrow = document.createElement("span");
+      arrow.className = "player-dropdown__arrow";
+      toggle.appendChild(arrow);
+
+      const menu = document.createElement("ul");
+      menu.className = "player-dropdown__menu";
+      const menuId = "player-menu-" + index;
+      menu.id = menuId;
+      menu.setAttribute("role", "menu");
+      toggle.setAttribute("aria-controls", menuId);
+      toggle.setAttribute("aria-expanded", "false");
+
+      toggle.addEventListener("click", () => {
+        const isOpen = dropdown.classList.contains("is-open");
+        if (isOpen) {
+          dropdown.classList.remove("is-open");
+          toggle.setAttribute("aria-expanded", "false");
+          if (activeDropdown === dropdown) {
+            activeDropdown = null;
+          }
+          return;
+        }
+        closeActiveDropdown();
+        dropdown.classList.add("is-open");
+        toggle.setAttribute("aria-expanded", "true");
+        activeDropdown = dropdown;
+      });
+
+      for (const player of players) {
+        const li = document.createElement("li");
+        const link = document.createElement("a");
+        link.href = buildPlayerUrl(player, item);
+        link.target = "_blank";
+        link.rel = "noreferrer";
+        link.setAttribute("role", "menuitem");
+
+        if (player.icon) {
+          const icon = document.createElement("img");
+          icon.src = player.icon;
+          icon.alt = "";
+          icon.width = 18;
+          icon.height = 18;
+          icon.setAttribute("aria-hidden", "true");
+          link.appendChild(icon);
+        }
+
+        const labelSpan = document.createElement("span");
+        labelSpan.textContent = player.label;
+        link.appendChild(labelSpan);
+        link.addEventListener("click", () => {
+          closeActiveDropdown();
+        });
+        li.appendChild(link);
+        menu.appendChild(li);
+      }
+
+      dropdown.appendChild(toggle);
+      dropdown.appendChild(menu);
+      return dropdown;
+    }
+
     function render(list) {
+      closeActiveDropdown();
       playlistContainer.innerHTML = "";
       if (!list.length) {
         const empty = document.createElement("p");
@@ -370,7 +658,7 @@ function buildHtml(entries) {
         return;
       }
 
-      for (const item of list) {
+      list.forEach((item, index) => {
         const card = document.createElement("article");
         card.className = "card";
         card.setAttribute("role", "listitem");
@@ -396,35 +684,16 @@ function buildHtml(entries) {
         const actions = document.createElement("div");
         actions.className = "actions";
 
-        const button = document.createElement("a");
-        button.className = "play";
-        button.href = item.url;
-        button.textContent = "Reproducir";
-        button.target = "_blank";
-        button.rel = "noreferrer";
-        actions.appendChild(button);
-
         if (players.length) {
-          const picker = document.createElement("details");
-          picker.className = "player-picker";
-          const summary = document.createElement("summary");
-          summary.textContent = "Seleccionar reproductor";
-          picker.appendChild(summary);
-          const listEl = document.createElement("ul");
-          listEl.className = "player-picker__list";
-
-          for (const player of players) {
-            const li = document.createElement("li");
-            const link = document.createElement("a");
-            link.textContent = player.label;
-            link.href = buildPlayerUrl(player, item.url);
-            link.target = "_blank";
-            link.rel = "noreferrer";
-            li.appendChild(link);
-            listEl.appendChild(li);
-          }
-          picker.appendChild(listEl);
-          actions.appendChild(picker);
+          actions.appendChild(createPlayerDropdown(item, index));
+        } else {
+          const fallbackLink = document.createElement("a");
+          fallbackLink.className = "play";
+          fallbackLink.href = item.url;
+          fallbackLink.textContent = "Reproducir";
+          fallbackLink.target = "_blank";
+          fallbackLink.rel = "noreferrer";
+          actions.appendChild(fallbackLink);
         }
 
         const copyBtn = document.createElement("button");
@@ -479,7 +748,7 @@ function buildHtml(entries) {
 
         card.appendChild(actions);
         playlistContainer.appendChild(card);
-      }
+      });
     }
 
     function applyFilters() {
@@ -519,7 +788,8 @@ function main() {
 
   const playlistContent = fs.readFileSync(targetPlaylistPath, "utf8");
   const entries = parseM3U8(playlistContent);
-  const html = buildHtml(entries);
+  const playerPresets = loadPlayerPresets();
+  const html = buildHtml(entries, playerPresets);
 
   fs.writeFileSync(path.join(docsDir, "index.html"), html, "utf8");
   fs.writeFileSync(path.join(docsDir, "playlist.json"), JSON.stringify(entries, null, 2), "utf8");

--- a/scripts/update-playlist.ps1
+++ b/scripts/update-playlist.ps1
@@ -2,7 +2,8 @@ param(
   [string]$PlaylistPath = "C:\\Users\\anton\\Documents\\playlist.m3u8",
   [switch]$AutoCommit,
   [string]$CommitMessage = "chore: update playlist",
-  [switch]$Push
+  [switch]$Push,
+  [string]$PlayerPresetPath
 )
 
 $repoRoot = (Resolve-Path "$PSScriptRoot/..\").Path
@@ -15,10 +16,21 @@ if (-not (Test-Path $PlaylistPath)) {
 
 Write-Host "[update-playlist] Generando pagina desde:" $PlaylistPath -ForegroundColor Cyan
 
+if ($PlayerPresetPath) {
+  Write-Host "[update-playlist] Usando presets personalizados:" $PlayerPresetPath -ForegroundColor Cyan
+  $env:PLAYER_PRESETS = $PlayerPresetPath
+}
+
 npm run generate:playlist -- "$PlaylistPath"
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "[update-playlist] npm run fallo (codigo $LASTEXITCODE)." -ForegroundColor Red
-  exit $LASTEXITCODE
+$exitCode = $LASTEXITCODE
+
+if ($PlayerPresetPath) {
+  Remove-Item Env:PLAYER_PRESETS -ErrorAction SilentlyContinue
+}
+
+if ($exitCode -ne 0) {
+  Write-Host "[update-playlist] npm run fallo (codigo $exitCode)." -ForegroundColor Red
+  exit $exitCode
 }
 
 if ($AutoCommit) {


### PR DESCRIPTION
## Summary
- add configurable player presets that can be supplied via playlists/player-presets.json or PLAYER_PRESETS
- enrich the generated playlist page to handle infohash-aware templates, optional icons, and cleaner dropdown styling
- extend the PowerShell helper and documentation so Windows users can pick their real AceCast/AceStream targets

## Testing
- npm run generate:playlist

------
https://chatgpt.com/codex/tasks/task_e_68dd90ac6e50832aa49ae55a478cb27f