### PR TITLE
chore: restore simple AceStream normalization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ npm run generate:playlist -- "C:\\Users\\anton\\Documents\\playlist.m3u8"
 
 > El flag `--` permite pasar la ruta como primer argumento. Si omites la ruta, usara `playlists/playlist.m3u8`.
 
+### Normalizar enlaces AceStream a tu motor remoto
+
+- **`scripts/normalize-acestream.ps1`** recorre todo el repo y reemplaza cualquier `acestream://<HASH>` o URLs antiguas de `/ace/getstream`/`/ace/manifest.m3u8` para que apunten a tu engine remoto con token.
+- Abre el script y ajusta las variables del bloque **CONFIG**:
+  - `$RepoRoot`: ruta local del repositorio.
+  - `$EngineHost`: base del engine (por ejemplo `http://80.39.151.195:6878`).
+  - `$Token`: token actual del engine.
+  - `$Extensions`: extensiones que quieres analizar.
+- Ejecuta el script desde PowerShell 5.1+ o PowerShell Core:
+
+  ```powershell
+  pwsh -File scripts/normalize-acestream.ps1
+  ```
+
+- El script genera copias `.bak` de cada archivo modificado y muestra un resumen con el número de coincidencias para que puedas revisar los cambios antes de hacer commit.
+
 Dentro de `packages/stremio-addon/` instala dependencias la primera vez:
 
 ```bash
@@ -87,14 +103,11 @@ Variables de entorno soportadas en el addon:
     - `{{infohash}}` / `{{infohash_encoded}}` - hash AceStream si el enlace lo incluye.
     - `{{title}}` / `{{title_encoded}}` - titulo del canal.
   - `icon` (opcional): ruta o URL a un icono de 18x18px para mostrar junto al nombre.
-codex/check-codex-resume-0199a171-5bae-7af0-abb3-f504f937df60-kzlk2n
 - Usa el bloque `availability` para mostrar cada reproductor solo cuando tenga sentido:
   - `platforms`: lista de etiquetas admitidas (`windows`, `mac`, `linux`, `ios`, `android`, `webos`, `smart-tv`, `desktop`, `mobile`, `tablet`, `safari`, `chrome`, `firefox`, etc.). Si ninguna coincide con tu dispositivo actual, ese reproductor se oculta.
   - `excludePlatforms`: etiquetas que deben ocultar el reproductor si el navegador pertenece a ellas.
   - `hostnames`: restringe a dominios concretos (útil si solo quieres que aparezca cuando entras desde una URL interna como `playlist.casita.local`).
   - `http`: lista de URLs (string o `{ url, method, timeout, mode, expectStatus }`) que el navegador intentará consultar. Solo si al menos una responde, el reproductor se mostrará. Esto permite detectar dispositivos en tu misma red (por ejemplo, `http://192.168.1.80:3000/ping`).
-
- main
 - Opcional: crea otros presets en un fichero alternativo y ejecútalo con `PLAYER_PRESETS=mi-archivo.json npm run generate:playlist`.
 - Cuando uses la variable `PLAYER_PRESETS`, la ruta se resuelve respecto a la raiz del repo (puedes pasar rutas absolutas si lo prefieres).
 - El script de PowerShell `scripts/update-playlist.ps1` acepta `-PlayerPresetPath "ruta\a\mis-presets.json"` para automatizar este override.
@@ -111,6 +124,7 @@ packages/
 scripts/
   dev-server.js        # Servidor estatico para el cliente web
   generate-playlist-page.js
+  normalize-acestream.ps1 # Normaliza enlaces AceStream al motor remoto
 playlists/
   playlist.m3u8        # Ultima copia versionada de tu lista
   player-presets.json  # Ejemplo de configuracion para el selector de reproductor

--- a/scripts/normalize-acestream.ps1
+++ b/scripts/normalize-acestream.ps1
@@ -1,0 +1,112 @@
+# =======================
+#  CONFIG (ajusta aquí)
+# =======================
+$RepoRoot   = "C:\\Users\\Public\\RepoComparison\\yavale"   # Raíz del repo
+$EngineHost = "http://80.39.151.195:6878"               # Base del engine
+$Token      = "qdfEbt9IzPwB"                            # Token del engine
+# Extensiones a procesar (añade/quita según tu repo)
+$Extensions = @("*.html","*.htm","*.md","*.json","*.js","*.ts","*.txt","*.m3u","*.m3u8")
+
+# =======================
+#  NO TOCAR DESDE AQUÍ
+# =======================
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (!(Test-Path $RepoRoot)) { throw "No existe la ruta: $RepoRoot" }
+
+# Normaliza base engine (sin / al final)
+$EngineBase = $EngineHost -replace "/+$",""
+
+# Regex para IDs AceStream (40 hex) y detección de esquemas
+$reAceID   = '(?<id>[A-Fa-f0-9]{40})'
+$reProto   = "acestream://$reAceID"
+$reOldGet  = '/ace/getstream\?id=(?<id>[A-Fa-f0-9]{40})(?:&[^""\s<>]*)?'
+$reOldHls  = '/ace/manifest\.m3u8\?id=(?<id>[A-Fa-f0-9]{40})(?:&[^""\s<>]*)?'
+
+# Función que, dado un ID, devuelve la URL HLS final con token
+function New-HlsUrl([string]$id) {
+  $tokenPart = if ([string]::IsNullOrEmpty($Token)) { "" } else { "&token=" + [System.Uri]::EscapeDataString($Token) }
+  return "$EngineBase/ace/manifest.m3u8?id=$id$tokenPart"
+}
+
+# Recorre archivos por extensión
+$files = foreach ($pat in $Extensions) {
+  Get-ChildItem -Path $RepoRoot -Recurse -File -Include $pat -ErrorAction SilentlyContinue
+}
+
+if (-not $files) {
+  Write-Host "No se encontraron archivos con las extensiones dadas." -ForegroundColor Yellow
+  return
+}
+
+$TotalChecked   = 0
+$TotalChanged   = 0
+$ChangesByFile  = @{}
+
+foreach ($f in $files) {
+  $TotalChecked++
+  $orig = Get-Content -Raw -LiteralPath $f.FullName
+
+  $changed = $orig
+
+  # 1) Reemplaza cualquier manifest/getstream existentes para apuntar a la base correcta y token nuevo
+  #    (unifica todo a HLS)
+  $changed = [regex]::Replace($changed, $reOldHls,  { param($m) New-HlsUrl $m.Groups['id'].Value })
+  $changed = [regex]::Replace($changed, $reOldGet,  { param($m) New-HlsUrl $m.Groups['id'].Value })
+
+  # 2) Reemplaza enlaces acestream://<ID> por HLS completo
+  $changed = [regex]::Replace($changed, $reProto,   { param($m) New-HlsUrl $m.Groups['id'].Value })
+
+  if ($changed -ne $orig) {
+    # Backup .bak una sola vez por archivo
+    $bak = "$($f.FullName).bak"
+    if (!(Test-Path $bak)) {
+      Copy-Item -LiteralPath $f.FullName -Destination $bak
+    }
+
+    # Guarda cambios
+    Set-Content -LiteralPath $f.FullName -Value $changed -NoNewline
+    $TotalChanged++
+
+    # Registra cambios por archivo
+    $ChangesByFile[$f.FullName] = $true
+  }
+}
+
+# Informe final
+Write-Host ""
+Write-Host "====================================" -ForegroundColor Cyan
+Write-Host " Archivos revisados : $TotalChecked"
+Write-Host " Archivos modificados: $TotalChanged"
+Write-Host " Engine base         : $EngineBase"
+Write-Host " Token aplicado      : $Token"
+Write-Host "====================================" -ForegroundColor Cyan
+
+if ($TotalChanged -gt 0) {
+  Write-Host "`nSe hicieron copias '.bak' de los archivos modificados." -ForegroundColor Yellow
+  Write-Host "Ejemplo de commit:" -ForegroundColor Green
+  Write-Host @"
+cd "$RepoRoot"
+git add .
+git commit -m "chore: normalizar enlaces AceStream a HLS remoto ($EngineBase) con token"
+git push origin main
+"@
+} else {
+  Write-Host "No se detectaron enlaces a cambiar." -ForegroundColor Yellow
+}
+
+# TIP opcional: validar que no quedan esquemas antiguos
+Write-Host "`nComprobando restos de 'acestream://', '/ace/getstream' y '/ace/manifest.m3u8' sin token..." -ForegroundColor Cyan
+$leftA = Select-String -Path $files.FullName -Pattern 'acestream://[A-Fa-f0-9]{40}' -SimpleMatch:$false
+$leftG = Select-String -Path $files.FullName -Pattern '/ace/getstream\?id=[A-Fa-f0-9]{40}(?![^""\s<>\r\n]*token=)' -SimpleMatch:$false
+$leftH = Select-String -Path $files.FullName -Pattern '/ace/manifest\.m3u8\?id=[A-Fa-f0-9]{40}(?![^""\s<>\r\n]*token=)' -SimpleMatch:$false
+
+if ($leftA -or $leftG -or $leftH) {
+  Write-Host "¡Ojo! Quedan posibles restos por revisar manualmente:" -ForegroundColor Yellow
+  if ($leftA){ Write-Host "  - acestream://  -> $($leftA | Select-Object -First 3 | ForEach-Object { $_.Path + ':' + $_.LineNumber })" }
+  if ($leftG){ Write-Host "  - /ace/getstream (sin token) -> $($leftG | Select-Object -First 3 | ForEach-Object { $_.Path + ':' + $_.LineNumber })" }
+  if ($leftH){ Write-Host "  - /ace/manifest.m3u8 (sin token) -> $($leftH | Select-Object -First 3 | ForEach-Object { $_.Path + ':' + $_.LineNumber })" }
+} else {
+  Write-Host "OK: no se encontraron patrones antiguos residuales." -ForegroundColor Green
+}


### PR DESCRIPTION
## Summary
- replace the advanced PowerShell implementation with the original straightforward normalization script and keep the configurable constants block intact
- update the README instructions to match the restored workflow and remove stray placeholder text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df00223c08832abcd34993ca22fc2c